### PR TITLE
feat: revisão de nomes a55

### DIFF
--- a/a55/Consult_PIX_In_Transactions_Microcash_API.yaml
+++ b/a55/Consult_PIX_In_Transactions_Microcash_API.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: Consult PIX In Transactions Microcash API
+  title: Consult PIX In Transactions A55 API
   version: 1.0.0
   description: Endpoint to consult PIX in transactions by transaction ID.
 paths:
@@ -30,7 +30,7 @@ paths:
                     example: 8992de72-610e-8c76-6dc6bf18bfd5
                   recebedorNome:
                     type: string
-                    example: Fastcash Pagamentos
+                    example: A55 Pagamentos
                   solicitacaoPagador:
                     type: string
                     example: informação
@@ -39,7 +39,7 @@ paths:
                     example: '50742495000100'
                   devedorNome:
                     type: string
-                    example: Fastcash
+                    example: A55
                   cidade:
                     type: string
                     example: Sao Paulo
@@ -100,7 +100,7 @@ paths:
                     example: false
                   urlPayloadJson:
                     type: string
-                    example: qrcode.microcashif.com.br/pix/6b89989a-62af-4db6-81e6-f0a8c34ef18a
+                    example: qrcode-h.pagsm.com.br/pix/6b89989a-62af-4db6-81e6-f0a8c34ef18a
                   payloadBase64:
                     type: string
                     example: MDAwMjAxMDEwMjEyMjY4ODAwMTRici5nb3YuYmNiLnBpeDI1NjZxcmNvZGUubWljcm9jYXNoaWYuY29tLmJyL3BpeC82Yjg5OTg5YS02MmFmLTRkYjYtODFlNi1mMGE4YzM0ZWYxOGE1MjA0MDAwMDUzMDM5ODY1ODAyQlI1OTE4SGtwIFBheSBQYWdhbWVudG9zNjAwOVNhbyBQYXVsbzYyMDcwNTAzKioqNjMwNDFEN0E

--- a/a55/Consult_a_PIX_Key_Microcash_API.yaml
+++ b/a55/Consult_a_PIX_Key_Microcash_API.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: Initiate a Pix Out/Consult a PIX Key Microcash API
+  title: Initiate a Pix Out/Consult a PIX Key A55 API
   version: 1.0.0
   description: Endpoint to initiate a Pix Out transaction or consult a PIX key.
 paths:

--- a/a55/Dynamic_QRCode_Generation_Microcash_API.yaml
+++ b/a55/Dynamic_QRCode_Generation_Microcash_API.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: Dynamic QRCode Generation Microcash API
+  title: Dynamic QRCode Generation A55 API
   version: 1.0.0
   description: Endpoint to generate dynamic QRCode for immediate Pix integration.
 paths:
@@ -27,7 +27,7 @@ paths:
                   example: '0000'
                 recebedorNome:
                   type: string
-                  example: Fastcash Pagamentos
+                  example: A55 Pagamentos
                 solicitacaoPagador:
                   type: string
                   example: informação
@@ -36,7 +36,7 @@ paths:
                   example: '50742495000100'
                 devedorNome:
                   type: string
-                  example: Fastcash
+                  example: A55
                 cidade:
                   type: string
                   example: Sao Paulo

--- a/a55/Microcash_Auth.yaml
+++ b/a55/Microcash_Auth.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: Microcash Auth
+  title: A55 Auth
   version: 1.0.0
   description: Endpoint to obtain OAuth2 token for Pix API client credentials.
 paths:

--- a/a55/PIX_In_Webhook_Microcash_API.yaml
+++ b/a55/PIX_In_Webhook_Microcash_API.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: PIX In Webhook Microcash API
+  title: PIX In Webhook A55 API
   version: 1.0.0
   description: Endpoint to receive webhook notifications for PIX In transactions.
 paths:

--- a/a55/PIX_Keys_Batch_Consultation_Microcash_API.yaml
+++ b/a55/PIX_Keys_Batch_Consultation_Microcash_API.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: PIX Keys Batch Consultation Microcash API
+  title: PIX Keys Batch Consultation A55 API
   version: 1.0.0
   description: API for consulting multiple PIX Keys in batch.
 paths:

--- a/a55/PIX_Out_Transactions_Microcash_API.yaml
+++ b/a55/PIX_Out_Transactions_Microcash_API.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: PIX Out Transactions Microcash API
+  title: PIX Out Transactions A55 API
   version: 1.0.0
   description: API for consulting PIX out transactions by EndToEndId or Tid.
 paths:

--- a/a55/Refund_PIX_In_Transactions_Microcash_API.yaml
+++ b/a55/Refund_PIX_In_Transactions_Microcash_API.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: Refund PIX In Transactions Microcash API
+  title: Refund PIX In Transactions A55 API
   version: 1.0.0
   description: Endpoint to refund PIX in transactions.
 paths:

--- a/a55/WebHook_PIX_Out_Microcash_API.yaml
+++ b/a55/WebHook_PIX_Out_Microcash_API.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: https://apis-pix-hml.a55scd.com
 info:
-  title: WebHook PIX Out Microcash API
+  title: WebHook PIX Out A55 API
   version: 1.0.0
   description: Endpoint to handle PIX Out WebHook notifications.
 paths:

--- a/a55/Webhook_de_Devolucao_PIX.yaml
+++ b/a55/Webhook_de_Devolucao_PIX.yaml
@@ -182,7 +182,7 @@ paths:
                         type: object
                     informacaoesEntreClientes:
                       type: string
-                      example: FASTCASHDINHE
+                      example: A55DINHE
                     creditoOrdemPagamento:
                       type: object
                       properties:


### PR DESCRIPTION
revisão nos docs do swagger para remover nome como microcash e fastcash e substituir por A55.

#27